### PR TITLE
Add environment setup scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+# Build artifacts
+**/bin/
+**/obj/
+
+# VS Code
+.vscode/
+
+# Libraries
+lib/
+
+# Logs
+*.log

--- a/README.md
+++ b/README.md
@@ -1,1 +1,22 @@
-read me file for repair mod
+# Repair Workbench Mod
+
+This repository contains a small example mod for Vintage Story. The `RepairWorkbenchMod backup 7 last broken version before butchery structure` directory holds the source code and assets. Use the provided scripts to set up a build environment.
+
+## Quick Start
+
+1. Install the required .NET SDK and copy game libraries:
+
+```bash
+./setup.sh
+```
+
+`setup.sh` expects the environment variable `VINTAGE_STORY` to point to your Vintage Story installation (where `VintagestoryAPI.dll` resides).
+
+2. Build the mod:
+
+```bash
+cd 'RepairWorkbenchMod backup 7 last broken version before butchery structure'
+dotnet build -c Release
+```
+
+The resulting DLL will be in `bin/Release/net7.0`.

--- a/RepairWorkbenchMod backup 7 last broken version before butchery structure/RepairWorkbenchMod.csproj
+++ b/RepairWorkbenchMod backup 7 last broken version before butchery structure/RepairWorkbenchMod.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <OutputType>Library</OutputType>
+    <AssemblyName>RepairWorkbench</AssemblyName>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="src/*.cs" />
+    <Reference Include="VintagestoryAPI">
+      <HintPath>../lib/VintagestoryAPI.dll</HintPath>
+    </Reference>
+    <Reference Include="VintagestoryLib">
+      <HintPath>../lib/VintagestoryLib.dll</HintPath>
+    </Reference>
+    <Reference Include="OpenTK">
+      <HintPath>../lib/OpenTK.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+</Project>

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Ensure setup has been run
+if [ ! -d lib ]; then
+    echo "Missing ./lib directory. Run ./setup.sh first." >&2
+    exit 1
+fi
+
+cd 'RepairWorkbenchMod backup 7 last broken version before butchery structure'
+dotnet build -c Release

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+# Setup script for RepairWorkbenchMod development
+set -euo pipefail
+
+# Ensure dotnet SDK 8.0 is installed
+if ! command -v dotnet >/dev/null 2>&1; then
+    echo "Installing dotnet-sdk-8.0"
+    sudo apt-get update
+    sudo apt-get install -y dotnet-sdk-8.0
+fi
+
+echo "dotnet SDK version: $(dotnet --version)"
+
+echo "Checking Vintage Story installation path via \$VINTAGE_STORY"
+
+if [ -z "${VINTAGE_STORY:-}" ]; then
+    echo "Please export VINTAGE_STORY pointing to your Vintage Story game directory."
+    echo "Example: export VINTAGE_STORY=/path/to/VintageStory"
+    exit 1
+fi
+
+mkdir -p lib
+# copy necessary libraries for compilation
+for dll in VintagestoryAPI.dll VintagestoryLib.dll OpenTK.dll; do
+    if [ ! -f "lib/$dll" ]; then
+        if [ -f "$VINTAGE_STORY/$dll" ]; then
+            cp "$VINTAGE_STORY/$dll" lib/
+        else
+            echo "Missing $dll in $VINTAGE_STORY"
+            exit 1
+        fi
+    fi
+done
+
+echo "Libraries copied to ./lib"
+
+echo "Environment setup complete"


### PR DESCRIPTION
## Summary
- add setup script for installing dotnet and copying game libraries
- add build helper script
- create csproj for building the mod
- update README with instructions
- add `.gitignore`

## Testing
- `./setup.sh` *(fails: VINTAGE_STORY not set)*
- `./build.sh` *(fails: Missing ./lib directory)*
- `dotnet build -c Release` in source folder *(fails: missing Vintagestory libraries)*

------
https://chatgpt.com/codex/tasks/task_b_6853e973438c83239dd1969e06bed15a