### PR TITLE
Fix docs and build script path

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Repair Workbench Mod
 
-This repository contains a small example mod for Vintage Story. The `RepairWorkbenchMod backup 7 last broken version before butchery structure` directory holds the source code and assets. Use the provided scripts to set up a build environment.
+This repository contains a small example mod for Vintage Story. The `RepairWorkbenchMod` directory holds the source code and assets. Use the provided scripts to set up a build environment.
 
 ## Quick Start
 
@@ -15,7 +15,7 @@ This repository contains a small example mod for Vintage Story. The `RepairWorkb
 2. Build the mod:
 
 ```bash
-cd 'RepairWorkbenchMod backup 7 last broken version before butchery structure'
+cd RepairWorkbenchMod
 dotnet build -c Release
 ```
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,7 @@
 # Repair Mod TODO
 
 ## Current State
-- The only code exists in `RepairWorkbenchMod backup 7 last broken version before butchery structure.zip`. Inside the archive the core classes are empty stubs:
+ - The `RepairWorkbenchMod` directory now contains the source code and assets:
   - `BlockRepairBench` derives from `Block` but has no logic.
   - `BlockEntityRepairBench` derives from `BlockEntity` but is empty.
   - `ItemRepairHammer` derives from `Item` without functionality.

--- a/build.sh
+++ b/build.sh
@@ -7,5 +7,5 @@ if [ ! -d lib ]; then
     exit 1
 fi
 
-cd 'RepairWorkbenchMod backup 7 last broken version before butchery structure'
+cd RepairWorkbenchMod
 dotnet build -c Release


### PR DESCRIPTION
## Summary
- update README steps
- fix build script path
- refresh TODO note

## Testing
- `./build.sh` *(fails: Missing ./lib directory. Run ./setup.sh first.)*
- `./setup.sh` *(fails: Please export VINTAGE_STORY pointing to your Vintage Story game directory.)*

------
https://chatgpt.com/codex/tasks/task_b_6853f2473af4832391aeb34d964649c2